### PR TITLE
Automated cherry pick of #302: fix(en): change title Documentation to Cloudpods

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
   - swordqiu
-  - yousong
-  - wanyaoqi
   - Zexi
   - ioito
   - tb365
 approvers:
   - swordqiu
-  - yousong
-  - wanyaoqi
   - Zexi

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "/"
-title = "Documentation"
+title = "Cloudpods"
 
 enableRobotsTXT = true
 


### PR DESCRIPTION
Cherry pick of #302 on release/3.7.

#302: fix(en): change title Documentation to Cloudpods