### PR TITLE
Automated cherry pick of #584: add ./config-ce-online.toml to fix contentDir config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ package-lock.json
 *.so
 *.swp
 
+# hugo
+.hugo_build.lock
 .content
 .assets
 .static

--- a/config-ce-online.toml
+++ b/config-ce-online.toml
@@ -1,0 +1,8 @@
+contentDir = "_output/content_ce_system/zh"
+
+[languages]
+[languages.zh]
+contentDir = "_output/content_ce_system/zh"
+
+[languages.en]
+contentDir = "_output/content_ce_system/en"

--- a/scripts/builder/hugo.py
+++ b/scripts/builder/hugo.py
@@ -91,7 +91,10 @@ class Hugo(object):
             dest = os.path.join(dest, ver_dir)
             base_url = base_url + '/' + ver_dir
 
-        cmd = ['hugo', '--minify',
+        cmd = ['hugo',
+               '--minify',
+               '--config=config.toml,config-ce-online.toml',
+               '--contentDir=%s' % self._content_dir,
                '--destination=%s' % dest,
                '--baseURL=%s' % base_url]
         run_process(['rm', '-rf', dest])


### PR DESCRIPTION
Cherry pick of #584 on release/3.8.

#584: add ./config-ce-online.toml to fix contentDir config