### PR TITLE
Automated cherry pick of #1883: fix: www.cloudpods.org switch from v1 to v2

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -98,7 +98,7 @@ time_format_blog = "02.01.2006"
 
 [[languages.zh.menu.main]]
     name = "新版文档"
-    url = "https://v2.cloudpods.org/"
+    url = "https://www.cloudpods.org/"
     weight = 2000
 
 [languages.en]


### PR DESCRIPTION
Cherry pick of #1883 on release/3.10.

#1883: fix: www.cloudpods.org switch from v1 to v2