### PR TITLE
Automated cherry pick of #1885: fix: change action host to v1.cloudpods.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Build public site
       run: |
-        ./scripts/build.py --host=https://www.cloudpods.org --edition=ce --multi-versions --no-out-fetch
+        ./scripts/build.py --host=https://v1.cloudpods.org --edition=ce --multi-versions --no-out-fetch
         ls -alh ./public
 
     # - name: Publish site


### PR DESCRIPTION
Cherry pick of #1885 on release/3.11.

#1885: fix: change action host to v1.cloudpods.org